### PR TITLE
LoadSound() fix (NOT TESTED) and memory leaks pacify

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -106,14 +106,19 @@ HB_FUNC( LOADSOUND )
       PHB_ITEM pSubarray = hb_arrayGetItemPtr( pLoadSoundArray, 1 );
 
       hb_arrayNew( pSubarray, 4 );
-      hb_arraySetPtr( pSubarray, 1, sound.stream.buffer );
       hb_arraySetNI( pSubarray, 2, ( unsigned int ) sound.stream.sampleRate );
       hb_arraySetNI( pSubarray, 3, ( unsigned int ) sound.stream.sampleSize );
       hb_arraySetNI( pSubarray, 4, ( unsigned int ) sound.stream.channels );
 
       hb_arraySetNI( pLoadSoundArray, 2, ( unsigned int ) sound.sampleCount );
 
+      PHB_ITEM pEmptyArray = hb_arrayGetItemPtr( pSubarray, 1 );
+      hb_arrayNew( pEmptyArray, 0 );
+      hb_arraySetPtr( pSubarray, 1, pEmptyArray );
+
       hb_itemReturnRelease( pLoadSoundArray );
+      hb_itemRelease( pSubarray );
+      hb_itemRelease( pEmptyArray );
    }
    else
    {

--- a/src/textures.c
+++ b/src/textures.c
@@ -1871,6 +1871,7 @@ HB_FUNC( LOADRENDERTEXTURE )
       hb_arraySetNI( pSubarray, 5, rendertexture2d.depth.format );
 
       hb_itemReturnRelease( pRenderTextureArray );
+      hb_itemRelease( pSubarray );
    }
    else
    {


### PR DESCRIPTION
* audio.c
  NOT TESTED! Changed LoadSound() returned array as per Rafal wishes
* textures.c
  avoided memory leaks releasing array items